### PR TITLE
bugfix: template for nsqadmin config was reading stats_prefix from 

### DIFF
--- a/manifests/nsqadmin.pp
+++ b/manifests/nsqadmin.pp
@@ -25,12 +25,13 @@
 #   Set logging level: debug, info, warn, error or fatal
 #
 class nsq::nsqadmin(
-  Boolean $service_manage                 = $::nsq::params::service_manage,
-  Variant[Boolean, Undef] $service_ensure = $::nsq::params::service_ensure,
-  String $http_address                    = '0.0.0.0:4171',
-  Array $nsqlookupd_addresses             = [ '127.0.0.1:4161' ],
-  String $statsd_prefix                   = $::nsq::params::statsd_prefix,
-  String $log_level                       = $::nsq::params::log_level,
+  Boolean $service_manage     = $::nsq::params::service_manage,
+  Variant[Boolean, Enum[true, false, 'running', 'stopped'], Undef]
+  $service_ensure             = $::nsq::params::service_ensure,
+  String $http_address        = '0.0.0.0:4171',
+  Array $nsqlookupd_addresses = [ '127.0.0.1:4161' ],
+  String $statsd_prefix       = $::nsq::params::statsd_prefix,
+  String $log_level           = $::nsq::params::log_level,
 ){
   include nsq::nsqadmin::config
 

--- a/manifests/nsqadmin.pp
+++ b/manifests/nsqadmin.pp
@@ -26,7 +26,7 @@
 #
 class nsq::nsqadmin(
   Boolean $service_manage     = $::nsq::params::service_manage,
-  Variant[Boolean, Enum[true, false, 'running', 'stopped'], Undef]
+  Variant[Boolean, Enum['running', 'stopped'], Undef]
   $service_ensure             = $::nsq::params::service_ensure,
   String $http_address        = '0.0.0.0:4171',
   Array $nsqlookupd_addresses = [ '127.0.0.1:4161' ],

--- a/manifests/nsqd.pp
+++ b/manifests/nsqd.pp
@@ -39,17 +39,18 @@
 #   Array of nsqlookupd addresses to connect to
 #
 class nsq::nsqd(
-  Boolean $service_manage                 = $::nsq::params::service_manage,
-  Variant[Boolean, Undef] $service_ensure = $::nsq::params::service_ensure,
-  Boolean $verbose_logging                = false,
-  String $log_level                       = $::nsq::params::log_level,
-  String $tcp_address                     = '0.0.0.0:4150',
-  String $http_address                    = '0.0.0.0:4151',
-  String $data_dir                        = $::nsq::params::data_dir,
-  String $statsd_address                  = $::nsq::params::statsd_address,
-  String $statsd_prefix                   = $::nsq::params::statsd_prefix,
-  Array $nsqlookupd_addresses             = [ '127.0.0.1:4160' ],
-  String $msg_timeout                     = $::nsq::params::msg_timeout,
+  Boolean $service_manage     = $::nsq::params::service_manage,
+  Variant[Boolean, Enum[true, false, 'running', 'stopped'], Undef]
+  $service_ensure             = $::nsq::params::service_ensure,
+  Boolean $verbose_logging    = false,
+  String $log_level           = $::nsq::params::log_level,
+  String $tcp_address         = '0.0.0.0:4150',
+  String $http_address        = '0.0.0.0:4151',
+  String $data_dir            = $::nsq::params::data_dir,
+  String $statsd_address      = $::nsq::params::statsd_address,
+  String $statsd_prefix       = $::nsq::params::statsd_prefix,
+  Array $nsqlookupd_addresses = [ '127.0.0.1:4160' ],
+  String $msg_timeout         = $::nsq::params::msg_timeout,
 ){
   include nsq::nsqd::config
 

--- a/manifests/nsqd.pp
+++ b/manifests/nsqd.pp
@@ -40,7 +40,7 @@
 #
 class nsq::nsqd(
   Boolean $service_manage     = $::nsq::params::service_manage,
-  Variant[Boolean, Enum[true, false, 'running', 'stopped'], Undef]
+  Variant[Boolean, Enum['running', 'stopped'], Undef]
   $service_ensure             = $::nsq::params::service_ensure,
   Boolean $verbose_logging    = false,
   String $log_level           = $::nsq::params::log_level,

--- a/manifests/nsqlookupd.pp
+++ b/manifests/nsqlookupd.pp
@@ -29,7 +29,8 @@
 #
 class nsq::nsqlookupd(
   Boolean $service_manage                 = $::nsq::params::service_manage,
-  Variant[Boolean, Undef] $service_ensure = $::nsq::params::service_ensure,
+  Variant[Boolean, Enum[true, false, 'running', 'stopped'], Undef]
+  $service_ensure                         = $::nsq::params::service_ensure,
   Boolean $verbose_logging                = false,
   String $log_level                       = $::nsq::params::log_level,
   String $tcp_address                     = '0.0.0.0:4160',

--- a/manifests/nsqlookupd.pp
+++ b/manifests/nsqlookupd.pp
@@ -29,7 +29,7 @@
 #
 class nsq::nsqlookupd(
   Boolean $service_manage                 = $::nsq::params::service_manage,
-  Variant[Boolean, Enum[true, false, 'running', 'stopped'], Undef]
+  Variant[Boolean, Enum['running', 'stopped', Undef]]
   $service_ensure                         = $::nsq::params::service_ensure,
   Boolean $verbose_logging                = false,
   String $log_level                       = $::nsq::params::log_level,

--- a/templates/nsqadmin.conf.erb
+++ b/templates/nsqadmin.conf.erb
@@ -22,10 +22,10 @@ statsd_interval = "60s"
 ## HTTP endpoint (fully qualified) to which POST notifications of admin actions will be sent
 notification_http_endpoint = ""
 
-
 ## nsqlookupd HTTP addresses
-nsqlookupd_http_addresses = [ <% scope.lookupvar('nsq::nsqadmin::nsqlookupd_addresses').each do |val| %>
-    "<%= val %>",
+nsqlookupd_http_addresses = [
+<% scope.lookupvar('nsq::nsqadmin::nsqlookupd_addresses').each do |val| -%>
+    "<%= val -%>",
 <% end -%>
 ]
 

--- a/templates/nsqadmin.conf.erb
+++ b/templates/nsqadmin.conf.erb
@@ -8,7 +8,7 @@ graphite_url = ""
 proxy_graphite = false
 
 ## prefix used for keys sent to statsd (%s for host replacement, must match nsqd)
-statsd_prefix = "<%= scope.lookupvar('nsq::nsqd::statsd_prefix') %>"
+statsd_prefix = "<%= scope.lookupvar('nsq::nsqadmin::statsd_prefix') %>"
 
 ## format of statsd counter stats
 statsd_counter_format = "stats.counters.%s.count"

--- a/templates/nsqd.conf.erb
+++ b/templates/nsqd.conf.erb
@@ -17,9 +17,10 @@ http_address = "<%= scope.lookupvar('nsq::nsqd::http_address') %>"
 # broadcast_address = ""
 
 ## cluster of nsqlookupd TCP addresses
-nsqlookupd_tcp_addresses = [ <% scope.lookupvar('nsq::nsqd::nsqlookupd_addresses').each do |val| %>
-    "<%= val %>",
-    <% end -%>
+nsqlookupd_tcp_addresses = [
+<% scope.lookupvar('nsq::nsqd::nsqlookupd_addresses').each do |val| -%>
+    "<%= val -%>",
+<% end -%>
 ]
 
 ## duration to wait before HTTP client connection timeout

--- a/templates/nsqlookupd.conf.erb
+++ b/templates/nsqlookupd.conf.erb
@@ -10,7 +10,6 @@ http_address = "<%= scope.lookupvar('nsq::nsqlookupd::http_address') %>"
 ## address that will be registered with lookupd (defaults to the OS hostname)
 # broadcast_address = ""
 
-
 ## duration of time a producer will remain in the active list since its last ping
 inactive_producer_timeout = "300s"
 


### PR DESCRIPTION
nsqd class instead of nsqadmin. This prevented setting this when nsqadmin is running on a host that does not run nsqd.